### PR TITLE
fix(MPX-2264): fallback to wallet_requestPermissions, when eth_requestAccounts fails

### DIFF
--- a/packages/connectors/connector/src/connectors/ethereum/injected.ts
+++ b/packages/connectors/connector/src/connectors/ethereum/injected.ts
@@ -116,8 +116,18 @@ async function enableProvider(provider: any) {
 			if (e && "code" in e && e.code === 4001) {
 				return
 			}
-			if (typeof provider.enable === "function") {
-				await provider.enable()
+
+			try {
+				// Attempt wallet_requestPermissions if eth_requestAccounts fails
+				// https://github.com/MetaMask/metamask-extension/issues/10085#issuecomment-1244107244
+				await provider.request({
+					method: "wallet_requestPermissions",
+					params: [{ eth_accounts: {} }],
+				})
+			} catch (e: any) {
+				if (typeof provider.enable === "function") {
+					await provider.enable()
+				}
 			}
 		}
 	} else {

--- a/packages/example/.eslintrc
+++ b/packages/example/.eslintrc
@@ -1,7 +1,8 @@
 {
   "extends": ["@rarible/ts"],
   "rules": {
-    "unicorn/no-empty-file": "off"
+    "unicorn/no-empty-file": "off",
+    "comma-dangle": "off"
   },
   "globals":{
     "BigInt": true


### PR DESCRIPTION
Issue happens when user already has an active eth_requestAccounts modal in metamask and tries to connect.

Steps to reproduce.
1. Close then open browser so metamask session is fresh.
2. Go to https://www.rarible.com/connect
3. Click on metamask connect but don't confirm connection in metamask modal
4. Refresh the page
5. Click on connect again. 
6. Right now an error is displyed. 