### PR TITLE
Create v3 orders when inverting v1

### DIFF
--- a/packages/ethereum/sdk/src/order/fill-order/rarible-v2.ts
+++ b/packages/ethereum/sdk/src/order/fill-order/rarible-v2.ts
@@ -41,10 +41,12 @@ export class RaribleV2OrderHandler implements OrderHandler<RaribleV2OrderFillReq
     const inverted = invertOrder(request.order, request.amount, maker)
     switch (request.order.data.dataType) {
       case "RARIBLE_V2_DATA_V1": {
+        const v3 = await this.shouldUseV3(request.originFees)
         inverted.data = {
-          dataType: "RARIBLE_V2_DATA_V1",
+          dataType: v3 ? "RARIBLE_V2_DATA_V3" : "RARIBLE_V2_DATA_V2",
           originFees: (request as RaribleV2OrderFillRequestV2).originFees || [],
           payouts: (request as RaribleV2OrderFillRequestV2).payouts || [],
+          isMakeFill: true, // for V1 order isMakeFill is always false, so inverted = true
         }
         break
       }


### PR DESCRIPTION
This kind of order combination is fully supported in the contracts already. Also, SDK is checked on ETH mainnet.
This is test tx for mixing v1 and v3 orders

https://etherscan.io/tx/0x1650a1de8b96fa7738d99c2fed31c2375584c35b1f2f01398d5e0d1b87e548c9