### PR TITLE
fix: settlus-testnet tx link

### DIFF
--- a/packages/transaction/src/ethereum/index.ts
+++ b/packages/transaction/src/ethereum/index.ts
@@ -164,7 +164,7 @@ export class BlockchainEthereumTransaction<TransactionResult = undefined>
       case "settlus":
         return `https://mainnet.settlus.network/tx/${this.hash()}`
       case "settlus-testnet":
-        return `https://eth-sepolia.blockscout.com/tx/${this.hash()}`
+        return `https://sepolia.settlus.network/tx/${this.hash()}`
       default:
         throw new Error("Unsupported transaction network")
     }


### PR DESCRIPTION
settlus testnet tx link should be `https://sepolia.settlus.network/tx/${this.hash()}`, not `https://eth-sepolia.blockscout.com/tx/${this.hash()}`